### PR TITLE
set AWS_CA_BUNDLE to an existing crt file

### DIFF
--- a/1/debian-10/Dockerfile
+++ b/1/debian-10/Dockerfile
@@ -21,6 +21,8 @@ RUN apt-get update && apt-get upgrade -y && \
     rm -r /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 
+# Fix https://github.com/bitnami/bitnami-docker-aws-cli/issues/1
+ENV AWS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 ENV BITNAMI_APP_NAME="aws-cli" \
     BITNAMI_IMAGE_VERSION="1.18.222-debian-10-r0" \
     PATH="/opt/bitnami/python/bin:/opt/bitnami/aws-cli/bin:/opt/bitnami/aws-cli/venv/bin:$PATH"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Fixes #1

Set `AWS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt` by default,
else TLS cert validation fails (at least) when talking to S3.

**Benefits**

CA certs used by aws-cli pre-set to the (widest) available
in the image.

**Possible drawbacks**

Unknown.

**Applicable issues**

#1

